### PR TITLE
scrollable resource card text

### DIFF
--- a/components/ResourceCard.tsx
+++ b/components/ResourceCard.tsx
@@ -49,7 +49,25 @@ export const ResourceCard = ({
             'DD MMM YYYY, h:mm a'
           )}`}
         </Text>
-        <Text overflowWrap="anywhere">{resource.details}</Text>
+        <Text
+          overflowWrap="anywhere"
+          overflowY="scroll"
+          maxHeight={300}
+          css={{
+            '&::-webkit-scrollbar': {
+              width: '4px',
+            },
+            '&::-webkit-scrollbar-track': {
+              width: '6px',
+            },
+            '&::-webkit-scrollbar-thumb': {
+              background: 'grey',
+              borderRadius: '24px',
+            },
+          }}
+        >
+          {resource.details}
+        </Text>
       </Stack>
       <HStack spacing="12px">
         <IconButton


### PR DESCRIPTION
I noticed that some of the `ResourceCard` components ended up taking way more space than the ones next to it creating a lot of white space so I thought it would make sense to make the cards scrollable and the text have a maxHeight. 300 is the number I got after messing around to make sure the least number of cards need to be scrollable. 


BEFORE:
![image](https://github.com/MutualAidNYC/services-lists/assets/25259737/620ebb3e-c634-44bb-83a8-ac4657d26659)


AFTER:
![image](https://github.com/MutualAidNYC/services-lists/assets/25259737/f4977538-8423-4b13-9469-3a1dc6379966)
