### PR TITLE
fixing minor UI issues

### DIFF
--- a/components/CollectionItem.tsx
+++ b/components/CollectionItem.tsx
@@ -31,7 +31,7 @@ const CollectionItem = ({
         </Heading>
         {/* TODO on click should let you edit the list and other actions */}
         <ShareLink
-          resourceURL={`${window.location.href}list/${servicesList.id}`}
+          resourceURL={`${window.location.origin}/list/${servicesList.id}`}
           title={servicesList.name}
           text={servicesList.description}
         />

--- a/components/CollectionItem.tsx
+++ b/components/CollectionItem.tsx
@@ -1,8 +1,8 @@
 import { Box, Heading, HStack, Link, Stack, Text } from '@chakra-ui/react'
 import { ServicesList } from 'models'
 import React from 'react'
-import { MoreVertical } from 'react-feather'
 import { formatDate } from 'utils'
+import { ShareLink } from './ShareLink'
 import { TaxonomySection } from './TaxonomySection'
 
 interface CollectionItemProps {
@@ -29,8 +29,12 @@ const CollectionItem = ({
         <Heading fontSize="subheading2" mb="16px">
           <Link href={`list/${servicesList.id}`}>{servicesList.name}</Link>
         </Heading>
-        {/* TODO on click should let you edit the list */}
-        <MoreVertical cursor={'pointer'} />
+        {/* TODO on click should let you edit the list and other actions */}
+        <ShareLink
+          resourceURL={`${window.location.href}list/${servicesList.id}`}
+          title={servicesList.name}
+          text={servicesList.description}
+        />
       </HStack>
       <Stack spacing="8px">
         <Text>{servicesList.description}</Text>

--- a/components/Collections.tsx
+++ b/components/Collections.tsx
@@ -45,12 +45,16 @@ export const Collections = ({ userData }: CollectionProps): JSX.Element => {
   return (
     <VStack alignItems="left" w="100%" spacing={4}>
       <ButtonGroup variant={'ghost'}>
-        <Button as="a" href="/">
-          Create New Collection
-        </Button>
-        <Button as="a" href="/">
+        {data?.length > 0 && (
+          <Button as="a" href="/">
+            Create New Collection
+          </Button>
+        )}
+
+        {/* Removing this for now until we have editing a collection set up*/}
+        {/* <Button as="a" href="/">
           Edit Collections
-        </Button>{' '}
+        </Button>{' '} */}
       </ButtonGroup>
 
       {data?.map((list) => (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -267,8 +267,8 @@ export const HomePage: NextPage = () => {
         <Grid
           templateColumns={{
             base: 'repeat(1, 1fr)',
-            md: 'repeat(2, 1fr)',
-            lg: 'repeat(3, 1fr)',
+            lg: 'repeat(2, 1fr)',
+            xl: 'repeat(3, 1fr)',
           }}
           gap="32px"
           py="32px"

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -22,7 +22,7 @@ export const ProfilePage: NextPage = () => {
   const [tabIndex, setTabIndex] = useState(0)
 
   return (
-    <Stack spacing="32px" w="100%" p={{ base: 4, md: 12 }}>
+    <Stack spacing="32px" w="100%" height={'100vh'} p={{ base: 4, md: 12 }}>
       <Head>
         <title>Resource Lists</title>
         <meta
@@ -67,7 +67,8 @@ export const ProfilePage: NextPage = () => {
               >
                 <TabList color="black">
                   <Tab _selected={{ fontWeight: 700 }}>My Collections</Tab>
-                  <Tab _selected={{ fontWeight: 700 }}>Profile</Tab>
+                  {/* Removing this for now until we have a profile section/ decide what to do there */}
+                  {/* <Tab _selected={{ fontWeight: 700 }}>Profile</Tab> */}
                 </TabList>
               </Tabs>
 


### PR DESCRIPTION
Overview
1. Stop displaying a profile tab on the account page, because we have no associated interface with a users profile data
2. Fix how weird and long the service cards look on the home page at `md` screen sizes.
3.  Add functionality to share a list that a user owns
4. Don't display create a collection 2x when a user has no collections
5. Make sure footer is aligned to the bottom on the account page

### before
![before](https://github.com/MutualAidNYC/services-lists/assets/25259737/dcd74606-47e2-4b24-a76e-c54cb9673785)

### after
![after](https://github.com/MutualAidNYC/services-lists/assets/25259737/c2211386-c10e-4756-8570-8f1b726e0593)

![resource_item](https://github.com/MutualAidNYC/services-lists/assets/25259737/916481ab-91a5-4952-bae8-a3eb93d48b2a)
