### PR TITLE
Remove the create list link from the navbar

### DIFF
--- a/components/Layout/Navbar.tsx
+++ b/components/Layout/Navbar.tsx
@@ -51,7 +51,6 @@ export const Navbar = (): JSX.Element => {
           </Link>
           <Link href="/">Resource hub</Link>
           <Link href="https://resources.mutualaid.nyc/">Resource library</Link>
-          <Link href="/create-list">Create new list</Link>
           <Link href="https://mutualaid.nyc/submit-a-resource/">
             Submit a resource
           </Link>
@@ -99,9 +98,6 @@ export const Navbar = (): JSX.Element => {
               </Link>
             </MenuItem>
             <MenuItem>
-              <Link href="/create-list">Create new list</Link>
-            </MenuItem>
-            <MenuItem>
               <Link href="https://mutualaid.nyc/submit-a-resource/">
                 Submit a resource
               </Link>
@@ -144,9 +140,6 @@ export const Navbar = (): JSX.Element => {
               <Link href="https://resources.mutualaid.nyc/">
                 Resource library
               </Link>
-            </MenuItem>
-            <MenuItem>
-              <Link href="/create-list">Create new list</Link>
             </MenuItem>
             <MenuItem>
               <Link href="https://mutualaid.nyc/submit-a-resource/">


### PR DESCRIPTION
This removes the create new list link from the navbar as per https://www.notion.so/manyc/Update-navbar-component-da40da128bc2471ba298f1882228b1d0?pvs=4. 

**Before**
<img width="1458" alt="Screenshot 2023-07-23 at 2 33 07 PM" src="https://github.com/MutualAidNYC/services-lists/assets/31671738/cc4a37c6-82bb-4e79-a07f-b9f4b48173f6">

**After**
<img width="1458" alt="Screenshot 2023-07-23 at 2 30 50 PM" src="https://github.com/MutualAidNYC/services-lists/assets/31671738/404d0229-a955-4da3-9c26-dd247b70bdab">
