### PR TITLE
Finished updating resource card

### DIFF
--- a/components/ResourceCard.tsx
+++ b/components/ResourceCard.tsx
@@ -27,8 +27,10 @@ export const ResourceCard = ({
       height="100%"
       direction="column"
       justify="space-between"
-    >
+      >
+      
       <Stack spacing="24px">
+        
         {resource.link ? (<Heading fontSize="2xl"><Link href={resource.link}>{resource.title}</Link></Heading>):(<Heading fontSize="2xl">{resource.title}</Heading>)}
       
         {resource.groupName && resource.groupName != NO_ASSOCIATED_GROUP && (
@@ -36,11 +38,20 @@ export const ResourceCard = ({
             {resource.groupName}
           </Text>
         )}
+
+
         {resource.needs && (
           <Text fontSize="xl" fontWeight="semibold" color="Gray.900">
             {`Need: ${resource.needs[0]}`}
           </Text>
         )}
+
+        {resource.neighborhoodNames ? (<Text>{resource.neighborhoodNames}</Text>): null }
+
+        {/* {resource.streetAddress ? (<Link >{resource.streetAddress}</Link>): null } */}
+
+        {resource.streetAddress ? (<Link href={"https://www.google.com/search?q=" + resource.streetAddress} target="_blank" rel="noopener noreferrer" >{resource.streetAddress}</Link>): null }
+
         <Text>
           {`Last Modified: ${dayjs(resource['Last Modified']).format(
             'DD MMM YYYY, h:mm a'


### PR DESCRIPTION
- [x] Display neighborhood (if it’s defined) since that’s one of the fields we filter by<br />
Not defined:<br />
<img src="https://github.com/MutualAidNYC/services-lists/assets/50630767/0fc39358-1c34-49f6-bb32-47f8f5e25687" width = 250><br />
Defined:<br />
<img src= "https://github.com/MutualAidNYC/services-lists/assets/50630767/984f341c-3228-43af-91a9-2cbb51e007a9" width = 250><br />
- [x] Display address if it’s defined<br />
<img src="https://github.com/MutualAidNYC/services-lists/assets/50630767/d3501055-7a22-406d-8c15-a22cdc405f33" width = 250> <br />
I added so that if a user clicks on the address it automatically looks it up on Google in a new tab